### PR TITLE
feat: Allow the tile to use for landfill to be configured

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const enum Settings {
   EntityInfoLocation = "bp100:entity-info-location",
   FlexibleOffshorePumpPlacement = "bp100:flexible-offshore-pump-placement",
   UpgradeOnPaste = "bp100:upgrade-on-paste",
+  LandfillTile = "bp100:landfill-tile",
 }
 
 // noinspection JSUnusedGlobalSymbols

--- a/src/locale.d.ts
+++ b/src/locale.d.ts
@@ -40,12 +40,16 @@ export declare const enum L_ModSettingName {
   EntityInfoLocation = "mod-setting-name.bp100:entity-info-location",
   /** Allow blueprint paste to upgrade entities */
   UpgradeOnPaste = "mod-setting-name.bp100:upgrade-on-paste",
+  /** Tile to use for landfill */
+  LandfillTile = "mod-setting-name.bp100:landfill-tile",
 }
 export declare const enum L_ModSettingDescription {
   /** Allow placing offshore pumps anywhere, without need for a water source. */
   FlexibleOffshorePumpPlacement = "mod-setting-description.bp100:flexible-offshore-pump-placement",
   /** For example, if pasting a blueprint with a fast-inserter over a normal inserter, this will upgrade the inserter. This is different from vanilla behavior.\nThis setting only applies while within a staged project. */
   UpgradeOnPaste = "mod-setting-description.bp100:upgrade-on-paste",
+  /** You can find the name to use by enabling show-debug-info-in-tooltips in the debug info ad look for the `tile-name` field */
+  LandfillTile = "mod-setting-description.bp100:landfill-tile",
 }
 export declare const enum L_StringModSetting {
   /** Top */

--- a/src/locale/en/en.cfg
+++ b/src/locale/en/en.cfg
@@ -22,10 +22,12 @@ bp100:utility=Staged bp planning: utility entities
 bp100:flexible-offshore-pump-placement=Place offshore pumps anywhere
 bp100:entity-info-location=Location of Entity info gui
 bp100:upgrade-on-paste=Allow blueprint paste to upgrade entities
+bp100:landfill-tile=Tile to use for landfill
 
 [mod-setting-description]
 bp100:flexible-offshore-pump-placement=Allow placing offshore pumps anywhere, without need for a water source.
 bp100:upgrade-on-paste=For example, if pasting a blueprint with a fast-inserter over a normal inserter, this will upgrade the inserter. This is different from vanilla behavior.\nThis setting only applies while within a staged project.
+bp100:landfill-tile=You can find the name to use by enabling show-debug-info-in-tooltips in the debug info ad look for the `tile-name` field
 
 [string-mod-setting]
 bp100:entity-info-location-top=Top

--- a/src/project/tiles.ts
+++ b/src/project/tiles.ts
@@ -12,14 +12,16 @@
 import { BoundingBox, LuaSurface, TileWrite } from "factorio:runtime"
 import { Mutable } from "../lib"
 import { BBox } from "../lib/geometry"
+import { Settings } from "../constants"
 
 function autoLandfill(surface: LuaSurface, area: BoundingBox): boolean {
   if (!waterLandfillTilesExist()) return false
   const tiles: Mutable<TileWrite>[] = []
   let i = 1
+  const tileName = settings.global[Settings.LandfillTile].value as string
   for (const [x, y] of BBox.roundTile(area).iterateTiles()) {
     tiles[i - 1] = {
-      name: "landfill",
+      name: tileName,
       position: { x, y },
     }
     i++
@@ -34,12 +36,13 @@ function autoLandfill(surface: LuaSurface, area: BoundingBox): boolean {
 
 function autoSetLandfillAndLabTiles(surface: LuaSurface, area: BoundingBox): boolean {
   if (!autoLandfill(surface, area)) return false
+  const tileName = settings.global[Settings.LandfillTile].value as string
   const landfillTiles = surface.find_tiles_filtered({
     area,
-    name: "landfill",
+    name: tileName,
   })
   const tiles = landfillTiles.map((tile) => ({
-    name: "landfill",
+    name: tileName,
     position: tile.position,
   }))
   surface.build_checkerboard(area)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,4 +39,11 @@ data.extend<StringSettingDefinition | BoolSettingDefinition>([
     default_value: false,
     order: "c",
   },
+  {
+    name: Settings.LandfillTile,
+    type: "string-setting",
+    setting_type: "runtime-global",
+    default_value: "landfill",
+    order: "d",
+  },
 ])


### PR DESCRIPTION
Part of my request in https://github.com/GlassBricks/StagedBlueprintPlanning/issues/12 .

Since this is a global setting there isn't a way to use different landfill tiles for different blueprints. That might be a nice thing to have but it is probably not worth cluttering up the interface for.

This does require one to lookup the name of the tile via the debug UI which isn't ideal but I don't have a better idea at this time.