### PR TITLE
feat: Support rotating inserters with custom drop/pickup locations

### DIFF
--- a/src/entity/Entity.d.ts
+++ b/src/entity/Entity.d.ts
@@ -34,6 +34,10 @@ export interface UndergroundBeltEntity extends Entity {
   type: "input" | "output"
 }
 export type LoaderEntity = UndergroundBeltEntity
+export interface InserterEntity extends Entity {
+    drop_position: Position
+    pickup_position: Position
+}
 export interface RollingStockEntity extends Entity {
   orientation?: RealOrientation
 }

--- a/src/entity/ProjectEntity.ts
+++ b/src/entity/ProjectEntity.ts
@@ -25,7 +25,7 @@ import {
 } from "../lib"
 import { Position } from "../lib/geometry"
 import { DiffValue, fromDiffValue, getDiff, toDiffValue } from "../utils/diff-value"
-import { Entity, LoaderEntity, RollingStockEntity, UndergroundBeltEntity } from "./Entity"
+import { Entity, InserterEntity, LoaderEntity, RollingStockEntity, UndergroundBeltEntity } from "./Entity"
 import {
   EntityPrototypeInfo,
   isPreviewEntity,
@@ -69,6 +69,7 @@ export interface ProjectEntity<out T extends Entity = Entity> {
 
   isRollingStock(): this is RollingStockProjectEntity
   isUndergroundBelt(): this is UndergroundBeltProjectEntity
+  isInserter(): this is InserterProjectEntity
 
   // inFirstStageOnly(): boolean
 
@@ -79,6 +80,8 @@ export interface ProjectEntity<out T extends Entity = Entity> {
   hasErrorAt(stage: StageNumber): boolean
 
   setTypeProperty(this: UndergroundBeltProjectEntity, direction: "input" | "output"): void
+  setDropPosition(this: InserterProjectEntity, position: Position): void
+  setPickupPosition(this: InserterProjectEntity, position: Position): void
 
   /** @return if this entity has any changes at the given stage, or any stage if nil */
   hasStageDiff(stage?: StageNumber): boolean
@@ -209,6 +212,7 @@ export interface StageProperties {
 export type RollingStockProjectEntity = ProjectEntity<RollingStockEntity>
 export type UndergroundBeltProjectEntity = ProjectEntity<UndergroundBeltEntity>
 export type LoaderProjectEntity = ProjectEntity<LoaderEntity>
+export type InserterProjectEntity = ProjectEntity<InserterEntity>
 
 type StageData = ExtraEntities & StageProperties
 
@@ -267,6 +271,9 @@ class ProjectEntityImpl<T extends Entity = Entity> implements ProjectEntity<T> {
   isUndergroundBelt(): this is UndergroundBeltProjectEntity {
     return nameToType.get(this.firstValue.name) == "underground-belt"
   }
+  isInserter(): this is InserterProjectEntity {
+    return nameToType.get(this.firstValue.name) == "inserter"
+  }
 
   isInStage(stage: StageNumber): boolean {
     return stage >= this.firstStage && !this.isPastLastStage(stage)
@@ -290,6 +297,13 @@ class ProjectEntityImpl<T extends Entity = Entity> implements ProjectEntity<T> {
   setTypeProperty(this: ProjectEntityImpl<UndergroundBeltEntity>, direction: "input" | "output"): void {
     // assume compiler asserts this is correct
     this.firstValue.type = direction
+  }
+
+  setDropPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
+      this.firstValue.drop_position = position
+  }
+  setPickupPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
+      this.firstValue.pickup_position = position
   }
 
   hasStageDiff(stage?: StageNumber): boolean {

--- a/src/project/project-updates.ts
+++ b/src/project/project-updates.ts
@@ -21,12 +21,14 @@ import {
   RollingStockProjectEntity,
   StageNumber,
   UndergroundBeltProjectEntity,
+  InserterProjectEntity,
 } from "../entity/ProjectEntity"
 import { canBeAnyDirection, forceFlipUnderground, saveEntity } from "../entity/save-load"
 import { findUndergroundPair } from "../entity/underground-belt"
 import { saveWireConnections } from "../entity/wires"
 import { updateAllHighlights } from "./entity-highlights"
 import { Project } from "./ProjectDef"
+import { Pos } from "../lib/geometry/position"
 import {
   deleteWorldEntities,
   makeSettingsRemnant,
@@ -226,6 +228,12 @@ function handleUpdate(
       if (entityType == "loader" || entityType == "loader-1x1") {
         assume<LoaderProjectEntity>(entity)
         entity.setTypeProperty(entitySource.loader_type)
+      } else if (entityType == "inserter") {
+        assume<InserterProjectEntity>(entity)
+        // Need a relative position when setting the positions, but we only get an absolute when retrieving them from the source
+        // So we need to translate them
+        entity.setPickupPosition(Pos.minus(entitySource.pickup_position, entitySource.position))
+        entity.setDropPosition(Pos.minus(entitySource.drop_position, entitySource.position))
       }
     } else {
       refreshWorldEntityAtStage(project, entity, stage)


### PR DESCRIPTION
I think this is correct? I tried to mirror the handling of loaders here. Seems to work from manual testing at least.

Part of https://github.com/GlassBricks/StagedBlueprintPlanning/issues/28