### PR TITLE
feat: Support rotating placed inserters with custom drop/pickup locations

### DIFF
--- a/src/entity/Entity.d.ts
+++ b/src/entity/Entity.d.ts
@@ -35,8 +35,8 @@ export interface UndergroundBeltEntity extends Entity {
 }
 export type LoaderEntity = UndergroundBeltEntity
 export interface InserterEntity extends Entity {
-    drop_position: Position
-    pickup_position: Position
+  drop_position?: Position
+  pickup_position?: Position
 }
 export interface RollingStockEntity extends Entity {
   orientation?: RealOrientation

--- a/src/entity/Entity.d.ts
+++ b/src/entity/Entity.d.ts
@@ -34,6 +34,10 @@ export interface UndergroundBeltEntity extends Entity {
   type: "input" | "output"
 }
 export type LoaderEntity = UndergroundBeltEntity
+export interface InserterEntity extends Entity {
+    drop_position: Position
+    pickup_position: Position
+}
 export interface RollingStockEntity extends Entity {
   orientation?: RealOrientation
 }

--- a/src/entity/ProjectEntity.ts
+++ b/src/entity/ProjectEntity.ts
@@ -25,7 +25,7 @@ import {
 } from "../lib"
 import { Position } from "../lib/geometry"
 import { DiffValue, fromDiffValue, getDiff, toDiffValue } from "../utils/diff-value"
-import { Entity, LoaderEntity, RollingStockEntity, UndergroundBeltEntity } from "./Entity"
+import { Entity, InserterEntity, LoaderEntity, RollingStockEntity, UndergroundBeltEntity } from "./Entity"
 import {
   EntityPrototypeInfo,
   isPreviewEntity,
@@ -69,6 +69,7 @@ export interface ProjectEntity<out T extends Entity = Entity> {
 
   isRollingStock(): this is RollingStockProjectEntity
   isUndergroundBelt(): this is UndergroundBeltProjectEntity
+  isInserter(): this is InserterProjectEntity
 
   // inFirstStageOnly(): boolean
 
@@ -79,6 +80,8 @@ export interface ProjectEntity<out T extends Entity = Entity> {
   hasErrorAt(stage: StageNumber): boolean
 
   setTypeProperty(this: UndergroundBeltProjectEntity, direction: "input" | "output"): void
+  setDropPosition(this: InserterProjectEntity, position: Position): void
+  setPickupPosition(this: InserterProjectEntity, position: Position): void
 
   /** @return if this entity has any changes at the given stage, or any stage if nil */
   hasStageDiff(stage?: StageNumber): boolean
@@ -209,6 +212,7 @@ export interface StageProperties {
 export type RollingStockProjectEntity = ProjectEntity<RollingStockEntity>
 export type UndergroundBeltProjectEntity = ProjectEntity<UndergroundBeltEntity>
 export type LoaderProjectEntity = ProjectEntity<LoaderEntity>
+export type InserterProjectEntity = ProjectEntity<InserterEntity>
 
 type StageData = ExtraEntities & StageProperties
 
@@ -267,6 +271,9 @@ class ProjectEntityImpl<T extends Entity = Entity> implements ProjectEntity<T> {
   isUndergroundBelt(): this is UndergroundBeltProjectEntity {
     return nameToType.get(this.firstValue.name) == "underground-belt"
   }
+  isInserter(): this is InserterProjectEntity {
+    return nameToType.get(this.firstValue.name) == "inserter"
+  }
 
   isInStage(stage: StageNumber): boolean {
     return stage >= this.firstStage && !this.isPastLastStage(stage)
@@ -290,6 +297,13 @@ class ProjectEntityImpl<T extends Entity = Entity> implements ProjectEntity<T> {
   setTypeProperty(this: ProjectEntityImpl<UndergroundBeltEntity>, direction: "input" | "output"): void {
     // assume compiler asserts this is correct
     this.firstValue.type = direction
+  }
+
+  setDropPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
+      this.firstValue.drop_position = position
+  }
+  setPickupPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
+      this.firstValue.pickup_position = position
   }
 
   hasStageDiff(stage?: StageNumber): boolean {

--- a/src/entity/ProjectEntity.ts
+++ b/src/entity/ProjectEntity.ts
@@ -80,8 +80,8 @@ export interface ProjectEntity<out T extends Entity = Entity> {
   hasErrorAt(stage: StageNumber): boolean
 
   setTypeProperty(this: UndergroundBeltProjectEntity, direction: "input" | "output"): void
-  setDropPosition(this: InserterProjectEntity, position: Position): void
-  setPickupPosition(this: InserterProjectEntity, position: Position): void
+  setDropPosition(this: InserterProjectEntity, position: Position | nil): void
+  setPickupPosition(this: InserterProjectEntity, position: Position | nil): void
 
   /** @return if this entity has any changes at the given stage, or any stage if nil */
   hasStageDiff(stage?: StageNumber): boolean
@@ -299,11 +299,11 @@ class ProjectEntityImpl<T extends Entity = Entity> implements ProjectEntity<T> {
     this.firstValue.type = direction
   }
 
-  setDropPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
-      this.firstValue.drop_position = position
+  setDropPosition(this: ProjectEntityImpl<InserterEntity>, position: Position | nil): void {
+    this.firstValue.drop_position = position
   }
-  setPickupPosition(this: ProjectEntityImpl<InserterEntity>, position: Position): void {
-      this.firstValue.pickup_position = position
+  setPickupPosition(this: ProjectEntityImpl<InserterEntity>, position: Position | nil): void {
+    this.firstValue.pickup_position = position
   }
 
   hasStageDiff(stage?: StageNumber): boolean {

--- a/src/project/project-updates.ts
+++ b/src/project/project-updates.ts
@@ -20,12 +20,14 @@ import {
   RollingStockProjectEntity,
   StageNumber,
   UndergroundBeltProjectEntity,
+  InserterProjectEntity,
 } from "../entity/ProjectEntity"
 import { canBeAnyDirection, forceFlipUnderground, saveEntity } from "../entity/save-load"
 import { findUndergroundPair } from "../entity/underground-belt"
 import { saveWireConnections } from "../entity/wires"
 import { Project } from "./ProjectDef"
 import { WorldEntityUpdates } from "./world-entity-updates"
+import { Pos } from "../lib/geometry/position"
 import min = math.min
 
 export declare const enum EntityUpdateResult {
@@ -275,6 +277,12 @@ export function ProjectUpdates(project: Project, worldEntityUpdates: WorldEntity
         if (entityType == "loader" || entityType == "loader-1x1") {
           assume<LoaderProjectEntity>(entity)
           entity.setTypeProperty(entitySource.loader_type)
+        } else if (entityType == "inserter") {
+            assume<InserterProjectEntity>(entity)
+            // Need a relative position when setting the positions, but we only get an absolute when retrieving them from the source
+            // So we need to translate them
+            entity.setPickupPosition(Pos.minus(entitySource.pickup_position, entitySource.position))
+            entity.setDropPosition(Pos.minus(entitySource.drop_position, entitySource.position))
         }
       } else {
         refreshWorldEntityAtStage(entity, stage)

--- a/src/project/project-updates.ts
+++ b/src/project/project-updates.ts
@@ -15,12 +15,12 @@ import { Entity } from "../entity/Entity"
 import { areUpgradeableTypes } from "../entity/entity-prototype-info"
 import {
   createProjectEntityNoCopy,
+  InserterProjectEntity,
   LoaderProjectEntity,
   ProjectEntity,
   RollingStockProjectEntity,
   StageNumber,
   UndergroundBeltProjectEntity,
-  InserterProjectEntity,
 } from "../entity/ProjectEntity"
 import { canBeAnyDirection, forceFlipUnderground, saveEntity } from "../entity/save-load"
 import { findUndergroundPair } from "../entity/underground-belt"
@@ -278,10 +278,13 @@ export function ProjectUpdates(project: Project, worldEntityUpdates: WorldEntity
           assume<LoaderProjectEntity>(entity)
           entity.setTypeProperty(entitySource.loader_type)
         } else if (entityType == "inserter") {
-            assume<InserterProjectEntity>(entity)
-            // Need a relative position when setting the positions, but we only get an absolute when retrieving them from the source
-            // So we need to translate them
+          assume<InserterProjectEntity>(entity)
+          // also update pickup and drop positions
+          // Need a relative position when setting the positions, but we only get an absolute when retrieving them from
+          // the source, so we need to translate them
+          if (entity.firstValue.pickup_position)
             entity.setPickupPosition(Pos.minus(entitySource.pickup_position, entitySource.position))
+          if (entity.firstValue.drop_position)
             entity.setDropPosition(Pos.minus(entitySource.drop_position, entitySource.position))
         }
       } else {

--- a/src/test/project/entity-update-integration.test.ts
+++ b/src/test/project/entity-update-integration.test.ts
@@ -1678,6 +1678,7 @@ if ("bobinserters" in script.active_mods) {
         position: Pos(0.5, 0.5),
         direction: direction.north,
         pickup_position: Pos(2, 1),
+        drop_position: Pos(1, 2),
       },
     ])
     player.teleport(pos, surfaces[3 - 1])
@@ -1690,14 +1691,49 @@ if ("bobinserters" in script.active_mods) {
     const projEntity = project.content.findCompatibleWithLuaEntity(builtEntity, nil, 1)!
 
     const rotatedPickupPos = Pos(1, -2)
+    const rotatedDropPos = Pos(2, -1)
 
     expect(projEntity).toBeAny()
     expect(projEntity).toMatchTable({
-      firstValue: { pickup_position: rotatedPickupPos },
+      firstValue: {
+        pickup_position: rotatedPickupPos,
+        drop_position: rotatedDropPos,
+      },
       direction: direction.west,
     })
     expect(builtEntity.pickup_position).toEqual(rotatedPickupPos.plus(pos))
+    expect(builtEntity.drop_position).toEqual(rotatedDropPos.plus(pos))
 
     assertEntityCorrect(projEntity, false)
+  })
+
+  test("when rotating an inserter, the pickup and drop positions also rotate", () => {
+    const entity = buildEntity(3, {
+      name: "inserter",
+      position: pos,
+      direction: direction.north,
+    })
+    entity.setPickupPosition(Pos(2, 1))
+    entity.setDropPosition(Pos(1, 2))
+    const worldEntity = entity.getWorldEntity(3)!
+    worldEntity.pickup_position = pos.plus(Pos(2, 1))
+    worldEntity.drop_position = pos.plus(Pos(1, 2))
+
+    worldEntity.rotate({ by_player: player, reverse: true })
+
+    const rotatedPickupPos = Pos(1, -2)
+    const rotatedDropPos = Pos(2, -1)
+
+    expect(entity).toMatchTable({
+      direction: direction.west,
+      firstValue: {
+        pickup_position: rotatedPickupPos,
+        drop_position: rotatedDropPos,
+      },
+    })
+    expect(worldEntity.pickup_position).toEqual(rotatedPickupPos.plus(pos))
+    expect(worldEntity.drop_position).toEqual(rotatedDropPos.plus(pos))
+
+    assertEntityCorrect(entity, false)
   })
 }


### PR DESCRIPTION
The fix that was just released only tackled rotation and flipping inserters that were in a blueprint or ghost. Pressing `R` to rotate an inserter that were already placed in the world still had the issue.