### PR TITLE
fix: Use the projects landfill tile when generating the blueprints

### DIFF
--- a/src/blueprints/blueprint-creation.ts
+++ b/src/blueprints/blueprint-creation.ts
@@ -17,7 +17,7 @@ import { BBox, Pos, Position } from "../lib/geometry"
 import { EnumeratedItemsTask, runEntireTask, submitTask } from "../lib/task"
 import { L_GuiBlueprintBookTask } from "../locale"
 import { Stage, UserProject } from "../project/ProjectDef"
-import { setTilesAndCheckerboard } from "../project/set-tiles"
+import { setTilesForStage } from "../project/set-tiles"
 import { getCurrentValues } from "../utils/properties-obj"
 import {
   getDefaultBlueprintSettings,
@@ -146,10 +146,7 @@ namespace BlueprintMethods {
     projectPlan.moduleOverrides!.set(result)
   }
 
-  export function setLandfill(stage: Stage): void {
-    const tile = stage.project.landfillTile.get() ?? "landfill"
-    setTilesAndCheckerboard(stage.surface, stage.getBlueprintBBox(), tile)
-  }
+  export const setLandfill = setTilesForStage
 
   export function takeStageBlueprint(
     stagePlan: StageBlueprintPlan,

--- a/src/blueprints/blueprint-creation.ts
+++ b/src/blueprints/blueprint-creation.ts
@@ -147,7 +147,8 @@ namespace BlueprintMethods {
   }
 
   export function setLandfill(stage: Stage): void {
-    setTilesAndCheckerboard(stage.surface, stage.getBlueprintBBox(), "landfill")
+    const tile = stage.project.landfillTile.get() ?? "landfill"
+    setTilesAndCheckerboard(stage.surface, stage.getBlueprintBBox(), tile)
   }
 
   export function takeStageBlueprint(

--- a/src/test/blueprints/blueprint-creation.test.ts
+++ b/src/test/blueprints/blueprint-creation.test.ts
@@ -75,7 +75,7 @@ test("can take single blueprint using stage settings", () => {
 
 describe("set tiles", () => {
   const setTiles = moduleMock(_setTiles, true)
-  test("calls setTiles if setTilesAndWater is true", () => {
+  test("calls setTiles if autoLandfill is true", () => {
     const stage = project.getStage(1)!
 
     const stack = player.cursor_stack!
@@ -83,13 +83,13 @@ describe("set tiles", () => {
 
     let ret = takeStageBlueprint(stage, stack)
     expect(ret).toBe(true)
-    expect(setTiles.setTilesAndCheckerboard).not.toHaveBeenCalled()
+    expect(setTiles.setTilesForStage).not.toHaveBeenCalled()
 
     stage.stageBlueprintSettings.autoLandfill.set(true)
 
     ret = takeStageBlueprint(stage, stack)
     expect(ret).toBe(true)
-    expect(setTiles.setTilesAndCheckerboard).toHaveBeenCalledWith(stage.surface, expect.anything(), "landfill")
+    expect(setTiles.setTilesForStage).toHaveBeenCalledWith(stage)
   })
 })
 


### PR DESCRIPTION
Seems like updating this location was missed in #32 .

Tried to add a test but I haven't been able to get factorio-test working yet.