### PR TITLE
Normalize pickup and drop positions in event handler

### DIFF
--- a/src/project/event-handlers.ts
+++ b/src/project/event-handlers.ts
@@ -741,7 +741,7 @@ function handleEntityMarkerBuilt(e: OnBuiltEntityEvent, entity: LuaEntity, tags:
       passedValue = editPassedValue<InserterBlueprintEntityWrite>(passedValue, (inserter) => {
         if (inserter.pickup_position) {
           inserter.pickup_position = transform(
-            inserter.pickup_position as MapPosition,
+            Pos.normalize(inserter.pickup_position) as MapPosition,
             bpState.flipHorizontal,
             bpState.flipVertical,
             bpState.direction,
@@ -749,7 +749,7 @@ function handleEntityMarkerBuilt(e: OnBuiltEntityEvent, entity: LuaEntity, tags:
         }
         if (inserter.drop_position) {
           inserter.drop_position = transform(
-            inserter.drop_position as MapPosition,
+            Pos.normalize(inserter.drop_position) as MapPosition,
             bpState.flipHorizontal,
             bpState.flipVertical,
             bpState.direction,


### PR DESCRIPTION
The pickup and drop positions here are actually arrays instead of tables with x and y fields causing the data to be lost. I just edited the lua files to test locally, haven't compiled the TS.

Fixes https://github.com/GlassBricks/StagedBlueprintPlanning/issues/65