### PR TITLE
Add missing colon in changelog

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -53,7 +53,7 @@ Date: 2025-11-09
 ---------------------------------------------------------------------------------------------------
 Version: 2.7.1
 Date: 2025-11-02
-  Bugfixes
+  Bugfixes:
     - Fixed handling of item requests for fuel and nutrients.
     - Fixed several issues relating to bot item requests.
     - Duplicate item requests highlights will no longer appear on some entities.


### PR DESCRIPTION
Don't have time to do a proper check that this is the only problem, but it is the one factorio is complaining about.

```Error ModInfoPane.cpp:500: Failed to parse changelog for mod bp100: invalid changelog file, error on line 52, category line does not end with colon.```

If I get a chance I'll check in game tomorrow.

It would be nice if factorio had a command line option to check a mod changelog without loading and going through the whole gui. Without that for automatic testing the only options seem to be a very heavy gui automation test or writing a simple parser that checks conformity to the format given on the wiki. Neither seems great but the latter might not be too unreasonable.